### PR TITLE
Fix default canonicalization

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -570,6 +570,19 @@ SignedXml.prototype.loadReference = function(ref) {
     });
   }
   
+/**
+ * DigestMethods take an octet stream rather than a node set. If the output of the last transform is a node set, we
+ * need to canonicalize the node set to an octet stream using non-exclusive canonicalization. If there are no
+ * transforms, we need to canonicalize because URI dereferencing for a same-document reference will return a node-set.
+ * See:
+ * https://www.w3.org/TR/xmldsig-core1/#sec-DigestMethod
+ * https://www.w3.org/TR/xmldsig-core1/#sec-ReferenceProcessingModel
+ * https://www.w3.org/TR/xmldsig-core1/#sec-Same-Document
+ */
+  if (transforms.length === 0 || transforms[transforms.length - 1] === "http://www.w3.org/2000/09/xmldsig#enveloped-signature") {
+      transforms.push("http://www.w3.org/TR/2001/REC-xml-c14n-20010315")
+  }
+
   this.addReference(null, transforms, digestAlgo, utils.findAttr(ref, "URI").value, digestValue, inclusiveNamespacesPrefixList, false)
 }
 


### PR DESCRIPTION
Summary:
According to the Digest Method Spec [1], the DigestMethod takes a octet stream, ad if the output of the URI dereference is a node set instead, it needs to be converted as described in the Reference Processing Spec [2] to an octet stream. The Reference Processing Spec says to use Canonical XML. Enveloped Signature returns a node-set, as does dereferencing a same-document reference [3], [4]. Canonicalization algorithms are the only other transforms we support, and they all return an octet stream, so the only times we need to add canonicalization are if we haven't done any transforms or if the last one is enveloped signature. 

1. https://www.w3.org/TR/xmldsig-core1/#sec-DigestMethod
2. https://www.w3.org/TR/xmldsig-core1/#sec-ReferenceProcessingModel
3. https://www.w3.org/TR/xmldsig-core1/#sec-EnvelopedSignature
4. https://www.w3.org/TR/xmldsig-core1/#sec-Same-Document

Tests:
Added back the test from when this was implemented slightly differently for Windows Mobile, checked against a SamlResponse without a canonicalization method in the transforms

Reviewer: @srir 
