### PR TITLE
enveloped-signature - only remove immediate child sigs

### DIFF
--- a/lib/enveloped-signature.js
+++ b/lib/enveloped-signature.js
@@ -6,7 +6,7 @@ function EnvelopedSignature() {
 }
 
 EnvelopedSignature.prototype.process = function (node) {
-  var signature = xpath(node, ".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];  
+  var signature = xpath(node, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];  
   if (signature) signature.parentNode.removeChild(signature);
   return node;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-crypto",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Xml digital signature and encryption library for Node.js",
   "engines": {
     "node": ">=0.4.0"


### PR DESCRIPTION
212200b changed the xpath to match all signature nodes descended from
the specified local node. This is incorrect; the relevant spec says that
only immediate signature elements should be removed

This commit corrects the behaviour simply by changing the xpath to only
match immediate children

Fixes yaronn/xml-crypto#135 , where further discussion can be found