### PR TITLE
Add inclusive namespace workaround

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -480,6 +480,33 @@ SignedXml.prototype.validateReferences = function(doc) {
     var hash = this.findHashAlgorithm(ref.digestAlgorithm)
     var digest = hash.getHash(canonXml)
 
+    // TODO: Determine if we can use the solution described here, which is more exhaustive
+    // https://github.com/yaronn/xml-crypto/pull/179
+    // https://app.asana.com/0/815188709102173/1192410228611214
+    if (digest !== ref.digestValue) {
+      if (ref.inclusiveNamespacesPrefixList) {
+        // fallback: apply InclusiveNamespaces workaround (https://github.com/yaronn/xml-crypto/issues/72)
+        var prefixList = ref.inclusiveNamespacesPrefixList instanceof Array ? ref.inclusiveNamespacesPrefixList : ref.inclusiveNamespacesPrefixList.split(' ');
+        var supported_definitions = {
+          'xs': 'http://www.w3.org/2001/XMLSchema',
+          'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+          'saml': 'urn:oasis:names:tc:SAML:2.0:assertion'
+        }
+
+        prefixList.forEach(function (prefix) {
+          if (supported_definitions[prefix]) {
+            elem[0].setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:' + prefix, supported_definitions[prefix]);
+          }
+        });
+
+        canonXml = this.getCanonXml(ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList });
+        digest = hash.getHash(canonXml);
+        if (digest === ref.digestValue) {
+          return true;
+        }
+      }
+    }
+
     if (digest!=ref.digestValue) {
       this.validationErrors.push("invalid signature: for uri " + ref.uri +
                                 " calculated digest is "  + digest +


### PR DESCRIPTION
Add "inclusive namespace workaround" to `SignedXml.validateReferences`.
This will fix the [SAML issue](https://app.asana.com/0/815188709102173/1191087470041955) currently being experienced by AT&T.

Initially added by @srir [here](https://github.com/Asana/codez/pull/87647)